### PR TITLE
Add manifest v2

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -1,0 +1,22 @@
+build:
+  api:
+    context: api
+  frontend:
+    context: frontend
+
+deploy:
+  - helm upgrade --install movies chart  --set api.image=${OKTETO_BUILD_API_IMAGE} --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}
+
+dev:
+  api:
+    command: bash
+    sync:
+      - api:/src
+    forward:
+      - 9229:9229
+
+  frontend:
+    image: okteto/node:14
+    command: bash
+    sync:
+      - frontend:/usr/src/app


### PR DESCRIPTION
Since `okteto init` isn't creating a working manifest, let's commit the okteto manifest to simplify the getting started guide