### PR TITLE
Return working response for /api endpoint

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -53,6 +53,10 @@ function startWithRetry() {
 
       console.log("Server running on port 8080.");
     });
+
+    app.get("/api", (req, res, next) => {
+      res.sendStatus(418);
+    });
   });
 };
 


### PR DESCRIPTION
Deploying this repo yields two endpoints in the Okteto UI:

<img width="846" alt="Screenshot 2023-04-21 at 14 54 49" src="https://user-images.githubusercontent.com/978461/233641264-0931440d-c9f8-4456-847e-a61831af96b8.png">

But only the first endpoint works (i.e the frontend app/UI), `/api` yields the default error fallback which makes the example to look kinda broken:
<img width="380" alt="Screenshot 2023-04-21 at 14 55 18" src="https://user-images.githubusercontent.com/978461/233641362-f4bd25bf-fcb4-4e50-ad00-ebe770c94672.png">

Fixing that by adding a handler for the default API endpoint, too so it displays something that appear to be working at least:

<img width="381" alt="Screenshot 2023-04-21 at 14 59 01" src="https://user-images.githubusercontent.com/978461/233642051-4ba1fb1a-002f-4e21-89ee-83f269017f85.png">
